### PR TITLE
Add existing path context to websocket requests

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -156,7 +156,8 @@ function handleWebSocket(message) {
   socket = new WebSocket(`ws://${window.location.host}/ws?model=${selectedModel}`);
   
   socket.onopen = () => {
-    socket.send(message);
+    const paths = Array.from(els.svg.querySelectorAll('path')).map(p => p.outerHTML);
+    socket.send(JSON.stringify({ prompt: message, paths }));
     els.input.value = '';
   };
 


### PR DESCRIPTION
## Summary
- allow frontend to send all current SVG paths with the prompt
- parse `paths` field server-side and pass it to the model streamer
- update `ModelStreamer` API to accept existing paths and combine them with the prompt

## Testing
- `python -m py_compile app.py model_streamer.py svg_utils.py`
